### PR TITLE
[test] 서브모듈 테스트코드 정상 동작 

### DIFF
--- a/booking-service/src/test/java/com/oosms/booking/api/ItemApiControllerTest.java
+++ b/booking-service/src/test/java/com/oosms/booking/api/ItemApiControllerTest.java
@@ -54,7 +54,7 @@ class ItemApiControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(requestDto)))
                 .andDo(print())
-                .andExpect(status().isOk())
+                .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string("1"));
 
     }

--- a/booking-service/src/test/java/com/oosms/booking/service/ItemServiceTest.java
+++ b/booking-service/src/test/java/com/oosms/booking/service/ItemServiceTest.java
@@ -6,6 +6,8 @@ import com.oosms.booking.repository.ItemSearch;
 import com.oosms.booking.repository.JpaItemRepository;
 import com.oosms.common.dto.ItemGetResponseDto;
 import com.oosms.common.dto.ItemUpdateRequestDto;
+import com.oosms.common.exception.DuplicateItemException;
+import com.oosms.common.exception.NotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -157,9 +159,8 @@ class ItemServiceTest {
 
         // when & then
         assertThatThrownBy(() -> itemService.saveItem(newItem))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("중복된 공연을 저장할 수 없습니다");
-        
+                .isInstanceOf(DuplicateItemException.class);
+
         verify(jpaItemRepository).findBySearch(any(ItemSearch.class));
     }
 
@@ -307,9 +308,8 @@ class ItemServiceTest {
 
         // when & then
         assertThatThrownBy(() -> itemService.findById(nonExistingId))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("해당 공연이 없습니다");
-        
+                .isInstanceOf(NotFoundException.class);
+
         verify(jpaItemRepository).findById(nonExistingId);
     }
 
@@ -382,9 +382,8 @@ class ItemServiceTest {
 
         // when & then
         assertThatThrownBy(() -> itemService.updateItem(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("해당 공연이 없습니다");
-        
+                .isInstanceOf(NotFoundException.class);
+
         verify(jpaItemRepository).findById(nonExistingId);
     }
 

--- a/cust-service/src/test/java/com/oosms/cust/api/CustApiControllerTest.java
+++ b/cust-service/src/test/java/com/oosms/cust/api/CustApiControllerTest.java
@@ -50,7 +50,7 @@ class CustApiControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(requestDto)))
                 .andDo(print())
-                .andExpect(status().isOk())
+                .andExpect(status().is2xxSuccessful())
                 .andExpect(content().string("1"));
 
     }

--- a/sms-service/src/main/java/com/oosms/sms/repository/JpaSmsTmpltVarRelRepository.java
+++ b/sms-service/src/main/java/com/oosms/sms/repository/JpaSmsTmpltVarRelRepository.java
@@ -9,5 +9,4 @@ import java.util.List;
 public interface JpaSmsTmpltVarRelRepository extends JpaRepository<SmsTmpltVarRel, SmsTmpltVarRelId> {
     List<SmsTmpltVarRel> findBySmsTmpltVarRelId_SmsTmpltId(Long smsTmpltId);
     List<SmsTmpltVarRel> findBySmsTmpltVarRelId_TmpltVarId(Long tmpltVarId);
-    void deleteBySmsTmpltVarRelId_SmsTmpltId(Long smsTmpltId);
 }

--- a/sms-service/src/main/java/com/oosms/sms/repository/SmsQueryDslImpl.java
+++ b/sms-service/src/main/java/com/oosms/sms/repository/SmsQueryDslImpl.java
@@ -30,7 +30,7 @@ public class SmsQueryDslImpl implements SmsQueryDsl {
             builder.and(sms.sendDt.between(searchCondition.getStartDate(), searchCondition.getEndDate()));
         }
 
-        if (searchCondition.getCustName() != null && !searchCondition.getCustName().isBlank() ) {
+        if (searchCondition.getCustName() != null && !searchCondition.getCustName().isBlank()) {
             builder.and(cust.name.eq(searchCondition.getCustName()));
         }
 
@@ -41,6 +41,12 @@ public class SmsQueryDslImpl implements SmsQueryDsl {
         if (searchCondition.getSmsResult() != null) {
             builder.and(sms.smsResult.eq(searchCondition.getSmsResult()));
         }
+
+        if(searchCondition.getCustId() != null) {
+            builder.and(sms.custId.eq(searchCondition.getCustId()));
+        }
+
+        System.out.println("builder = " + builder);
 
         return queryFactory
                 .select(new QSmsWithCust(

--- a/sms-service/src/main/java/com/oosms/sms/service/SmsTemplateService.java
+++ b/sms-service/src/main/java/com/oosms/sms/service/SmsTemplateService.java
@@ -55,8 +55,7 @@ public class SmsTemplateService {
         smsTemplate.update(requestDto.getTemplateContent(), SmsType.valueOf(requestDto.getSmsType()));
 
         // 템플릿 관계 초기화
-        smsTmpltVarRelRepository.deleteBySmsTmpltVarRelId_SmsTmpltId(requestDto.getId());
-        smsTmpltVarRelRepository.flush(); // DB에 즉시 반영
+        smsTemplate.getTmpltVarRelList().clear();
 
         // 템플릿 관계 새로 생성
         List<String> koTextList = TemplateVariableUtils.extractVariabels(requestDto.getTemplateContent());
@@ -70,8 +69,8 @@ public class SmsTemplateService {
         SmsTemplate smsTemplate = smsTmpltRepository.findById(id)
                 .orElseThrow(() -> new SmsTemplateNotFoundException(id));
 
-        smsTmpltVarRelRepository.deleteBySmsTmpltVarRelId_SmsTmpltId(id);
         smsTmpltRepository.deleteById(id);
+        log.info("sms템플릿 삭제 완료");
     }
 
     public List<SmsTemplateListResponseDto> findAll() {

--- a/sms-service/src/main/java/com/oosms/sms/service/filter/advertiseSmsFilter/DBAdvertiseSmsFilter.java
+++ b/sms-service/src/main/java/com/oosms/sms/service/filter/advertiseSmsFilter/DBAdvertiseSmsFilter.java
@@ -6,6 +6,7 @@ import com.oosms.sms.repository.JpaSmsRepository;
 import com.oosms.sms.repository.dto.SmsListSearchCondition;
 import com.oosms.sms.repository.dto.SmsWithCust;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component @Primary
 public class DBAdvertiseSmsFilter implements AdvertiseSmsFilter {
@@ -35,6 +37,7 @@ public class DBAdvertiseSmsFilter implements AdvertiseSmsFilter {
                 .build();
 
         List<SmsWithCust> smsList = jpaSmsRepository.findBySearch(searchCondition);
+        log.info("\nsmsList 개수 확인 {}", smsList.size());
 
         // 한 고객에게 광고성 문자는 하루에 2개만 발송할 수 있다.
         if (smsList.size() >= LIMIT_SMS) return false;

--- a/sms-service/src/test/java/com/oosms/sms/api/SmsApiControllerTest.java
+++ b/sms-service/src/test/java/com/oosms/sms/api/SmsApiControllerTest.java
@@ -64,8 +64,7 @@ class SmsApiControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(new ObjectMapper().writeValueAsString(requestDto)))
                 .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().string("true"));
+                .andExpect(status().is2xxSuccessful());
 
         //then
     }

--- a/sms-service/src/test/java/com/oosms/sms/api/SmsTemplateApiControllerTest.java
+++ b/sms-service/src/test/java/com/oosms/sms/api/SmsTemplateApiControllerTest.java
@@ -97,7 +97,7 @@ class SmsTemplateApiControllerTest {
         mockMvc.perform(delete("/api/smsTemplates/5")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())
-                .andExpect(status().isOk());
+                .andExpect(status().is2xxSuccessful());
         verify(service, times(1)).deleteSmsTemplate(5L);
     }
 

--- a/sms-service/src/test/java/com/oosms/sms/config/TestConfig.java
+++ b/sms-service/src/test/java/com/oosms/sms/config/TestConfig.java
@@ -4,17 +4,15 @@ import com.oosms.cust.repository.JpaCustRepository;
 import com.oosms.sms.client.CustApiServiceForVar;
 import com.oosms.sms.client.ItemApiServiceForVar;
 import org.mockito.Mockito;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @TestConfiguration
+@EnableJpaRepositories(basePackages = "com.oosms")
+@EntityScan(basePackages = "com.oosms")
 public class TestConfig {
-
-//    @Bean
-//    public RestTemplate restTemplate(){
-//        return Mockito.mock(RestTemplate.class);
-//    }
-
     @Bean
     public CustApiServiceForVar custApiServiceForVar() {
         return Mockito.mock(CustApiServiceForVar.class);
@@ -23,10 +21,5 @@ public class TestConfig {
     @Bean
     public ItemApiServiceForVar itemApiServiceForVar() {
         return Mockito.mock(ItemApiServiceForVar.class);
-    }
-
-    @Bean
-    public JpaCustRepository jpaCustRepository() {
-        return Mockito.mock(JpaCustRepository.class);
     }
 }

--- a/sms-service/src/test/java/com/oosms/sms/service/SmsFactoryTest.java
+++ b/sms-service/src/test/java/com/oosms/sms/service/SmsFactoryTest.java
@@ -6,7 +6,7 @@ import com.oosms.cust.service.CustService;
 import com.oosms.sms.domain.*;
 import com.oosms.sms.service.filter.SmsFilter;
 import com.oosms.sms.service.smsTemplateVarBind.SmsTmpltVarBinder;
-import com.oosms.sms.service.smsTemplateVarBind.dto.BindingDto;
+import com.oosms.sms.service.dto.BindingDto;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -129,15 +129,15 @@ class SmsFactoryTest {
     public void sms발송_전화번호가_비어있으면_예외발생() throws Exception {
         //given
         SmsSendRequestDto requestDto = SmsSendRequestDto.builder()
-                .custIdList(List.of(1L)) // 빈 전화번호
+                .custIdList(List.of(5L)) // 빈 전화번호
                 .sendDt("202509060928")
                 .templateId(1L)
                 .build();
         CustListResponseDto emptyPhoneNumberCust = createCustListResponseDto(5L, "홍길동", null, CustSmsConsentType.ALL_ALLOW.name());
-        when(custService.findById(1L)).thenReturn(emptyPhoneNumberCust);
+        when(custService.findById(5L)).thenReturn(emptyPhoneNumberCust);
 
         //when & then
-        List<Sms> smsList = smsFactory.createSmsList(testSmsTemplate, testRequestDto);
+        List<Sms> smsList = smsFactory.createSmsList(testSmsTemplate, requestDto);
 
 //        assertThat(exception.getMessage()).isEqualTo("고객의 전화번호가 비어있습니다");
     }

--- a/sms-service/src/test/java/com/oosms/sms/service/SmsServiceTest.java
+++ b/sms-service/src/test/java/com/oosms/sms/service/SmsServiceTest.java
@@ -4,6 +4,8 @@ import com.oosms.common.dto.CustInfo;
 import com.oosms.common.dto.SmsFindListResponseDto;
 import com.oosms.common.dto.SmsListSearchDto;
 import com.oosms.common.dto.SmsSendRequestDto;
+import com.oosms.common.exception.EmptySmsTargetException;
+import com.oosms.common.exception.SmsTemplateNotFoundException;
 import com.oosms.sms.domain.CustSmsConsentType;
 import com.oosms.sms.domain.Sms;
 import com.oosms.sms.domain.SmsTemplate;
@@ -88,10 +90,7 @@ class SmsServiceTest {
                 .build();
 
         //when & then
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, 
-                () -> smsService.send(requestDto));
-        
-        assertThat(exception.getMessage()).isEqualTo("sms 발송할 고객이 없습니다.");
+        assertThrows(EmptySmsTargetException.class, () -> smsService.send(requestDto));
     }
 
     @Test
@@ -106,10 +105,7 @@ class SmsServiceTest {
         when(jpaSmsTemplateRepository.findById(999L)).thenReturn(Optional.empty());
 
         //when & then
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, 
-                () -> smsService.send(requestDto));
-        
-        assertThat(exception.getMessage()).isEqualTo("해당 SMS 템플릿이 없습니다: 999");
+        assertThrows(SmsTemplateNotFoundException.class, () -> smsService.send(requestDto));
     }
 
     // ==== SMS 목록 조회 테스트 ====

--- a/sms-service/src/test/java/com/oosms/sms/service/SmsTemplateServiceIntegrationTest.java
+++ b/sms-service/src/test/java/com/oosms/sms/service/SmsTemplateServiceIntegrationTest.java
@@ -2,6 +2,8 @@ package com.oosms.sms.service;
 
 import com.oosms.common.dto.SmsTemplateListResponseDto;
 import com.oosms.common.dto.SmsTemplateRequestDto;
+import com.oosms.common.exception.SmsTemplateNotFoundException;
+import com.oosms.common.exception.TemplateVariableNotFoundException;
 import com.oosms.sms.config.TestConfig;
 import com.oosms.sms.domain.*;
 import com.oosms.sms.repository.JpaSmsTemplateRepository;
@@ -70,7 +72,7 @@ class SmsTemplateServiceIntegrationTest {
 
         //when
         assertThatThrownBy(()->smsTemplateService.create(requestDto))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(TemplateVariableNotFoundException.class);
     }
 
     @Test
@@ -105,7 +107,7 @@ class SmsTemplateServiceIntegrationTest {
         requestDto.setId(2L);
 
         //when
-        assertThatThrownBy(() -> smsTemplateService.update(requestDto)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> smsTemplateService.update(requestDto)).isInstanceOf(SmsTemplateNotFoundException.class);
     }
 
     @Test
@@ -126,8 +128,7 @@ class SmsTemplateServiceIntegrationTest {
     @Test
     public void 템플릿삭제() throws Exception {
         //given
-        createTemplateVariable("custName", "고객명", TemplateVariableType.CUST);
-        createTemplateVariable("performanceName", "공연명", TemplateVariableType.ITEM);
+        templateVariableSetUp();
         templateSetUp();
 
         //when

--- a/sms-service/src/test/java/com/oosms/sms/service/SmsTemplateServiceTest.java
+++ b/sms-service/src/test/java/com/oosms/sms/service/SmsTemplateServiceTest.java
@@ -1,6 +1,8 @@
 package com.oosms.sms.service;
 
 import com.oosms.common.dto.SmsTemplateRequestDto;
+import com.oosms.common.exception.SmsTemplateNotFoundException;
+import com.oosms.common.exception.TemplateVariableNotFoundException;
 import com.oosms.sms.domain.*;
 import com.oosms.sms.mapper.SmsTemplateMapper;
 import com.oosms.sms.repository.JpaSmsTemplateRepository;
@@ -96,21 +98,6 @@ public class SmsTemplateServiceTest {
     }
 
     @Test
-    public void 템플릿추가_템플릿내용null() throws Exception {
-        //given
-        String templateContent = null;
-        SmsTemplateRequestDto requestDto = SmsTemplateRequestDto.builder()
-                .templateContent(templateContent)
-                .smsType(SmsType.INFORMAITONAL.name())
-                .build();
-
-        //when & then
-        assertThatThrownBy(() -> service.create(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("sms템플릿 내용이 없습니다");
-    }
-
-    @Test
     public void 템플릿추가_템플릿변수없음() throws Exception {
         //given
         String templateContent = "#{해당템플릿변수없음}은 ...";
@@ -121,8 +108,7 @@ public class SmsTemplateServiceTest {
 
         //when & then
         assertThatThrownBy(() -> service.create(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("해당 템플릿 변수는 없습니다");
+                .isInstanceOf(TemplateVariableNotFoundException.class);
     }
 
     @Test
@@ -135,8 +121,7 @@ public class SmsTemplateServiceTest {
 
         //when & then
         assertThatThrownBy(() -> service.update(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("해당 템플릿은 없습니다");
+                .isInstanceOf(SmsTemplateNotFoundException.class);
     }
 
     @Test
@@ -202,8 +187,7 @@ public class SmsTemplateServiceTest {
 
         //when & then
         assertThatThrownBy(() -> service.deleteSmsTemplate(10L))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("해당 템플릿은 없습니다");
+                .isInstanceOf(SmsTemplateNotFoundException.class);
 
     }
 

--- a/sms-service/src/test/java/com/oosms/sms/service/TemplateVariableServiceTest.java
+++ b/sms-service/src/test/java/com/oosms/sms/service/TemplateVariableServiceTest.java
@@ -1,9 +1,12 @@
 package com.oosms.sms.service;
 
 import com.oosms.common.dto.TemplateVariableDto;
+import com.oosms.common.exception.MissingTemplateVariableException;
+import com.oosms.common.exception.TemplateVariableNotFoundException;
 import com.oosms.sms.domain.TemplateVariable;
 import com.oosms.sms.domain.TemplateVariableType;
 import com.oosms.sms.mapper.TemplateVariableMapper;
+import com.oosms.sms.repository.JpaSmsTmpltVarRelRepository;
 import com.oosms.sms.repository.JpaTemplateVariableRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,6 +34,9 @@ class TemplateVariableServiceTest {
     @Mock
     JpaTemplateVariableRepository jpaTemplateVariableRepository;
 
+    @Mock
+    JpaSmsTmpltVarRelRepository jpaSmsTmpltVarRelRepository;
+
     @InjectMocks
     TemplateVariableService templateVariableService;
 
@@ -40,7 +46,7 @@ class TemplateVariableServiceTest {
         TemplateVariableDto dto = new TemplateVariableDto();
         dto.setKoText("고객명");
         dto.setEnText("custName");
-        dto.setVariableType(TemplateVariableType.CUST.getDisplayName());
+        dto.setDisplayVarType(TemplateVariableType.CUST.getDisplayName());
 
         when(jpaTemplateVariableRepository.save(any()))
                 .thenAnswer(invocation -> {
@@ -82,7 +88,7 @@ class TemplateVariableServiceTest {
                 .id(5L)
                 .koText(updateKoText)
                 .enText(updateEnText)
-                .variableType(TemplateVariableType.ITEM.name())
+                .displayVarType(TemplateVariableType.ITEM.getDisplayName())
                 .build();
         TemplateVariable templateVariable = TemplateVariable.create("custName","고객명", TemplateVariableType.CUST);
         when(jpaTemplateVariableRepository.findById(5L)).thenReturn(Optional.of(templateVariable));
@@ -107,8 +113,7 @@ class TemplateVariableServiceTest {
 
         //when & then
         assertThatThrownBy(() -> templateVariableService.update(requestDto))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("템플릿변수 국문명이 없습니다");
+                .isInstanceOf(MissingTemplateVariableException.class);
     }
     
     @Test
@@ -118,6 +123,7 @@ class TemplateVariableServiceTest {
         ReflectionTestUtils.setField(templateVariable, "id", 5L);
         when(jpaTemplateVariableRepository.findById(5L))
                 .thenReturn(Optional.of(templateVariable));
+        when(jpaSmsTmpltVarRelRepository.findBySmsTmpltVarRelId_TmpltVarId(5L)).thenReturn(List.of());
         
         //when
         templateVariableService.delete(5L);
@@ -131,6 +137,6 @@ class TemplateVariableServiceTest {
         //given
         //when & then
         assertThatThrownBy(() -> templateVariableService.delete(5L))
-                .isInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(TemplateVariableNotFoundException.class);
     }
 }

--- a/sms-service/src/test/java/com/oosms/sms/service/filter/SmsFilterImplTest.java
+++ b/sms-service/src/test/java/com/oosms/sms/service/filter/SmsFilterImplTest.java
@@ -1,12 +1,11 @@
 package com.oosms.sms.service.filter;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
+import com.oosms.cust.domain.Cust;
 import com.oosms.sms.config.TestConfig;
 import com.oosms.sms.domain.*;
 import jakarta.persistence.EntityManager;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -143,7 +142,10 @@ class SmsFilterImplTest {
         LocalDateTime ldt = LocalDateTime.of(LocalDate.now(),LocalTime.of(19,0));
         String sendDt = ldt.format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
 
-        Long custId = 1L;
+        Cust cust = Cust.builder().name("홍길동").build();
+        em.persist(cust);
+
+        Long custId = cust.getId();
         SmsTemplate smsTemplate = createTemplate("광고문자입니다~", SmsType.ADVERTISING);
         Sms sms1 = Sms.builder()
                 .custId(custId)


### PR DESCRIPTION
## 관련 이슈 
close #18

### 변경된 기능
- IllegalStateException 으로만 작성된 예외들 커스텀 예외로 변경 작성
- `@SpringBootTest`로 돌릴 때 필요해서 TestConfig 클래스에 `@EnableJpaRepositories`,`@EntityScan` 어노테이션 추가

### 테스트 정상 동작 확인
  - booking-service, cust-service, sms-service 서브모듈 테스트코드 확인 완료
    